### PR TITLE
Fix deprecation warning for Aws::S3::Object#upload_file by replacing with Aws::S3::TransferManager#upload_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.8.1] (2025-09-16)
+
+### Bug Fixes
+
+* Fix deprecation warning for Aws::S3::Object#upload_file by replacing with Aws::S3::TransferManager#upload_file
+
 ## [0.8.0](https://github.com/manheim/eb_deployer/compare/v0.7.0...v0.8.0) (2023-10-17)
 
 

--- a/lib/eb_deployer/aws_driver/s3_driver.rb
+++ b/lib/eb_deployer/aws_driver/s3_driver.rb
@@ -14,13 +14,16 @@ module EbDeployer
       end
 
       def upload_file(bucket_name, obj_name, file)
-        o = obj(bucket_name, obj_name)
-        o.upload_file(file)
+        transfer_manager.upload_file(file, bucket_name, obj_name)
       end
 
       private
       def s3
         Aws::S3::Resource.new(client: Aws::S3::Client.new)
+      end
+
+      def transfer_manager
+        @transfer_manager ||= Aws::S3::TransferManager.new(client: Aws::S3::Client.new)
       end
 
       def obj(bucket_name, obj_name)

--- a/lib/eb_deployer/version.rb
+++ b/lib/eb_deployer/version.rb
@@ -1,3 +1,3 @@
 module EbDeployer
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
Full warning from 0.8.0


```
[2025-09-16 17:07:24 UTC][package:wp.zip] start uploading to s3 bucket wp.lowers.packages...
#################### DEPRECATION WARNING ####################
Called deprecated method `upload_file` of Aws::S3::Object. Use `Aws::S3::TransferManager#upload_file` instead.
Method `upload_file` will be removed in next major version.
#############################################################
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer/aws_driver/s3_driver.rb:18:in `upload_file'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer/package.rb:30:in `upload_if_not_exists'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer/package.rb:10:in `upload'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer/application.rb:22:in `create_version'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer.rb:235:in `deploy'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/lib/eb_deployer.rb:278:in `cli'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/man_eb_deployer-0.8.0/bin/eb_deploy:13:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.2.8/x64/bin/eb_deploy:25:in `load'
/opt/hostedtoolcache/Ruby/3.2.8/x64/bin/eb_deploy:25:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:58:in `load'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:58:in `kernel_load'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli/exec.rb:23:in `run'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli.rb:455:in `exec'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/command.rb:28:in `run'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor.rb:527:in `dispatch'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli.rb:35:in `dispatch'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/vendor/thor/lib/thor/base.rb:584:in `start'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/cli.rb:29:in `start'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/exe/bundle:28:in `block in <top (required)>'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/lib/bundler/friendly_errors.rb:117:in `with_friendly_errors'
/opt/hostedtoolcache/Ruby/3.2.8/x64/lib/ruby/gems/3.2.0/gems/bundler-2.5.18/exe/bundle:20:in `<top (required)>'
/opt/hostedtoolcache/Ruby/3.2.8/x64/bin/bundle:25:in `load'
/opt/hostedtoolcache/Ruby/3.2.8/x64/bin/bundle:25:in `<main>'
[2025-09-16 17:07:24 UTC][package:wp.zip] uploading finished

```